### PR TITLE
Fix HTML in Otto webapp

### DIFF
--- a/otto_webapp.ino
+++ b/otto_webapp.ino
@@ -18,9 +18,9 @@ const int servo2Pin = 4;
 
 const char index_html[] PROGMEM = R"rawliteral(
 <!DOCTYPE html>
-<html lang=\"en\">
+<html lang="en">
 <head>
-  <meta charset=\"UTF-8\">
+  <meta charset="UTF-8">
   <title>Otto Web Control</title>
   <style>
     body {
@@ -56,11 +56,11 @@ const char index_html[] PROGMEM = R"rawliteral(
   </script>
 </head>
 <body>
-  <div id=\"controls\">
-    <button id=\"forward\" onclick=\"sendCmd('forward')\">&#9650;</button>
-    <button id=\"left\" onclick=\"sendCmd('left')\">&#9664;</button>
-    <button id=\"right\" onclick=\"sendCmd('right')\">&#9654;</button>
-    <button id=\"backward\" onclick=\"sendCmd('backward')\">&#9660;</button>
+  <div id="controls">
+    <button id="forward" onclick="sendCmd('forward')">&#9650;</button>
+    <button id="left" onclick="sendCmd('left')">&#9664;</button>
+    <button id="right" onclick="sendCmd('right')">&#9654;</button>
+    <button id="backward" onclick="sendCmd('backward')">&#9660;</button>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- correct HTML attribute quotes in `index_html` raw string

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686b7ffee4e08328a1b6f5b4e3a7c821